### PR TITLE
feat(status-bar): add optional words counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this plugin are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Status bar can now display the total word count of the vault. A new "Show words" toggle joins the existing per-metric toggles; it is on by default and shows up alongside notes/links/tags in the rotation. Closes #23.
+
 ## [1.19.0] - 2026-06-04
 
 ### Changed

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,7 @@ function isPersistedData(raw: unknown): raw is PersistedData {
 const DEFAULT_SETTINGS: Partial<FullStatisticsPluginSettings> = {
 	displayIndividualItems: false,
 	showNotes: true,
+	showWords: true,
 	showLinks: true,
 	showTags: true,
 	showQuality: true,
@@ -469,6 +470,9 @@ class FullStatisticsStatusBarItem {
 			setStatisticName("notes").
 			setFormatter((s: FullVaultMetrics) => { return new DecimalUnitFormatter("notes").format(s.notes) }));
 		this.statisticViews.push(new StatisticView(this.statusBarItem).
+			setStatisticName("words").
+			setFormatter((s: FullVaultMetrics) => { return new DecimalUnitFormatter("words").format(s.words) }));
+		this.statisticViews.push(new StatisticView(this.statusBarItem).
 			setStatisticName("links").
 			setFormatter((s: FullVaultMetrics) => { return new DecimalUnitFormatter("links").format(s.links) }));
 		this.statisticViews.push(new StatisticView(this.statusBarItem).
@@ -523,6 +527,7 @@ class FullStatisticsStatusBarItem {
 		const s = this.owner.settings;
 		return [
 			s.showNotes,
+			s.showWords,
 			s.showLinks,
 			s.showTags,
 			s.showQuality,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -11,6 +11,7 @@ export interface FolderGroup {
 export interface FullStatisticsPluginSettings {
 	displayIndividualItems: boolean,
 	showNotes: boolean,
+	showWords: boolean,
 	showLinks: boolean,
 	showTags: boolean,
 	showQuality: boolean,
@@ -107,6 +108,18 @@ export class FullStatisticsPluginSettingTab extends PluginSettingTab {
 						.setValue(this.plugin.settings.showNotes)
 						.onChange(async (value) => {
 							this.plugin.settings.showNotes = value;
+							await this.plugin.saveSettings();
+						});
+				});
+
+			new Setting(containerEl)
+				.setName("Show words")
+				.setDesc("Total word count across the vault.")
+				.addToggle((value) => {
+					value
+						.setValue(this.plugin.settings.showWords)
+						.onChange(async (value) => {
+							this.plugin.settings.showWords = value;
 							await this.plugin.saveSettings();
 						});
 				});


### PR DESCRIPTION
## Summary

- Adds a **Show words** toggle to the per-metric status-bar toggles in settings.
- Wires `FullVaultMetrics.words` (already maintained by the collector) into the rotation of status-bar views via `DecimalUnitFormatter("words")`, matching the formatting of notes/links/tags.
- Default-on so users who relied on the words count in older versions get it back without touching settings.

Closes #23.

Context: requested in [discussion #21](https://github.com/jtprogru/obsidian-vault-full-statistics-plugin/discussions/21#discussioncomment-17202125) — total word count is already shown in the sidebar Statistics view; this surfaces it in the status bar too.

## Test plan

- [x] `npm test` — 173 passed
- [x] `npm run build` — clean (tsc + esbuild)
- [ ] Manual: enable plugin in vault, confirm "words" appears in the status bar rotation and in the multi-item view
- [ ] Manual: toggle "Show words" off and confirm the item disappears (multi-item) / is skipped (cycle mode)