### PR TITLE
refactor(settings): turn the settings tab into an index of pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this plugin are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+The settings tab became an index. The first screen used to be one scroll of 28 rows (40 with individual status bar items on), mixing a lone toggle, two blocks of checkboxes and four editable lists with the four navigable pages added in 1.21.0. Now it holds one toggle and ten navigable entries under three headings, each entry summarising its own state.
+
+### Changed
+- **Settings are organised into pages.** Top level: `Show individual items` and `Status bar items`, then **What gets counted** (excluded folders, note classification), **Side view** (metrics, folder breakdown, sources with trace, taxonomy drift, inbox health, history) and **Tools** (tangles). No setting was removed, renamed or given a new default — everything moved one level down and is still reachable from `Settings → Search`.
+- Every entry now carries a state summary: `11 of 12`, `3 own / 6 source`, `No folders`, `On + top 5`. Previously only four of them did.
+- Two more configurations that silently render nothing are flagged with a warning marker: every status bar item turned off, and an empty own or source tag list (the own/source ratio, which the hero panel is built on, has no meaning then).
+- The twelve status bar toggles and the five side view metric toggles are generated from one ordered list each. `StatusBarView` reads the same list to decide which statistics are enabled, so the settings tab and the status bar can no longer drift apart.
+- **`minAppVersion` raised from 1.13.0 to 1.13.1.** `displayValue` and `status` on a settings page landed in 1.13.1, and 1.21.0 already shipped them — the manifest has been understating the requirement since that release.
+
+### Fixed
+- The per-statistic status bar toggles are no longer hidden when `Show individual items` is off. Cycling mode walks only the enabled statistics and skips the rest, so those toggles were doing their job the whole time while the settings tab claimed otherwise and hid them.
+
+### Documentation
+- README's settings reference follows the new hierarchy and describes the index-plus-pages layout.
+
 ## [1.21.0] - 2026-08-01
 
 Settings are rebuilt on Obsidian 1.13's declarative settings API. The plugin's settings are now searchable from the settings panel, the long sections became navigable pages, and the tag/folder lists gained drag-to-reorder.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For pre-releases (testing unreleased features), use [BRAT](https://github.com/Tf
 
 Manual install: grab the latest `main.js`, `manifest.json`, and `styles.css` from the [release section](https://github.com/jtprogru/obsidian-vault-full-statistics-plugin/releases) and drop them into `<vault>/.obsidian/plugins/vault-full-statistics/`.
 
-This plugin is desktop-only and requires Obsidian 1.13.0 or newer. Earlier builds lack the declarative settings API the settings tab is built on; if you are on an older Obsidian, it will keep offering you 1.20.2, which works.
+This plugin is desktop-only and requires Obsidian 1.13.1 or newer. Earlier builds lack the declarative settings API the settings tab is built on, and the state summaries on its navigable entries; if you are on an older Obsidian, it will keep offering you 1.20.2, which works.
 
 ## Usage
 
@@ -63,21 +63,22 @@ For own/source classification, configure your own/source/concept tags in setting
 
 All settings live under `Settings → Community plugins → Vault Full Statistics`, and are searchable from the settings search box. Defaults are sensible — most users only touch own/source tags and the opt-in section toggles.
 
-Folder breakdown, Tag taxonomy drift, Inbox health and Tangles are navigable pages: the entry shows the current state (`3 groups`, `AND ≥ 5/5`, `Off`) and carries a warning marker when the section is enabled but configured to render nothing. Every list below supports drag-to-reorder and removal with Delete or Backspace.
+The tab itself is an index. The first screen holds one toggle and a list of navigable entries grouped under **What gets counted**, **Side view** and **Tools**; everything below lives one level down on its own page. Each entry shows its current state (`11 of 12`, `3 groups`, `AND ≥ 5/5`, `Off`) and carries a warning marker when the section is enabled but configured to render nothing. Every list supports drag-to-reorder and removal with Delete or Backspace. If you know what you are looking for, `Settings → Search` finds the row directly and opens the page it lives on.
 
 ### Status bar
-- **Show individual items** — when on, every enabled statistic is rendered as its own status bar slot; when off (default) the bar shows one statistic at a time and clicking cycles. Below toggles apply when this is on.
-- **Show notes / links / tags / quality / own / source / own % / source % / concepts / orphans / trace %** — visibility of each individual status bar stat.
+- **Show individual items** — when on, every enabled statistic is rendered as its own status bar slot; when off (default) the bar shows one statistic at a time and clicking cycles.
+- **Status bar items** — page with a toggle per statistic: **Show notes / words / links / tags / quality / own / source / own % / source % / concepts / orphans / trace %**. These apply in both modes; cycling walks only the enabled ones and skips the rest. All on by default except concepts.
 
-### Metrics section (side view)
+### What gets counted
+- **Excluded folders** — folders to skip entirely (templates, archives, plugin data). Added through the vault folder picker; matched as path prefix with a `/` boundary.
+- **Note classification** — the three tag sets behind own/source and the hero panel. The entry warns when either own or source is empty, because the ratio is meaningless then.
+  - **Own tags** (default: `thought`, `synthesis`, `fleeting`) — mark notes as your own thinking.
+  - **Source tags** (default: `book`, `article`, `video`, `lecture`, `literature`, `literature-note`) — mark notes about external material.
+  - **Concept tags** (default: `concept`) — the grey zone between own and source.
+
+### Metrics (side view)
 Toggle which secondary metrics appear in the side view's grid below the hero panel:
 - **Links**, **Tags**, **Concepts**, **Orphans**, **Avg words** — all on by default.
-
-### Classification
-- **Excluded folders** — folders to skip entirely (templates, archives, plugin data). Added through the vault folder picker; matched as path prefix with a `/` boundary.
-- **Own tags** (default: `thought`, `synthesis`, `fleeting`) — mark notes as your own thinking.
-- **Source tags** (default: `book`, `article`, `video`, `lecture`, `literature`, `literature-note`) — mark notes about external material.
-- **Concept tags** (default: `concept`) — the grey zone between own and source.
 
 ### Folder breakdown (PARA)
 - **Show folder breakdown** (default: off) — opt-in section that breaks down notes per folder group.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 	"id": "vault-full-statistics",
 	"name": "Vault Full Statistics",
 	"version": "1.21.0",
-	"minAppVersion": "1.13.0",
+	"minAppVersion": "1.13.1",
 	"description": "Vault statistics in the status bar plus a dedicated view with own/source ratio and a 30-day sparkline of how your knowledge base evolves.",
 	"author": "Mikhail Savin",
 	"authorUrl": "https://github.com/jtprogru",

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import { FolderPickerModal } from './pickers';
 import { DecimalUnitFormatter } from './format';
 import { FullVaultMetrics } from './metrics';
 import { FullVaultMetricsCollector } from './collect';
-import { DEFAULT_SETTINGS, FullStatisticsPluginSettings, FullStatisticsPluginSettingTab } from './settings';
+import { DEFAULT_SETTINGS, FullStatisticsPluginSettings, FullStatisticsPluginSettingTab, STATUS_BAR_ITEMS } from './settings';
 import { HistoryStore, Snapshot, snapshotsToCsv } from './historyStore';
 import { VaultStatisticsView, VAULT_STATISTICS_VIEW_TYPE } from './statisticsView';
 import { TanglesView, TANGLES_VIEW_TYPE } from './tanglesView';
@@ -479,22 +479,14 @@ class FullStatisticsStatusBarItem {
 
 	private refreshSoon = debounce(() => { this.refresh(); }, 2000, false);
 
+	/**
+	 * Positional against `statisticViews` above: STATUS_BAR_ITEMS is declared
+	 * in the same order the views are pushed, and the settings tab builds its
+	 * toggles from that same array, so the two can't drift apart.
+	 */
 	private viewEnabledFlags(): boolean[] {
 		const s = this.owner.settings;
-		return [
-			s.showNotes,
-			s.showWords,
-			s.showLinks,
-			s.showTags,
-			s.showQuality,
-			s.showOwn,
-			s.showSource,
-			s.showOwnPct,
-			s.showSourcePct,
-			s.showConcepts,
-			s.showOrphans,
-			s.showTracePct,
-		];
+		return STATUS_BAR_ITEMS.map(item => s[item.key] as boolean);
 	}
 
 	public refresh() {

--- a/src/settings.spec.ts
+++ b/src/settings.spec.ts
@@ -6,6 +6,7 @@ import {
 	FullStatisticsPluginSettingTab,
 	parseFolderGroups,
 	serializeFolderGroups,
+	STATUS_BAR_ITEMS,
 } from './settings';
 import type { FullStatisticsPluginSettings, SettingsKey } from './settings';
 
@@ -132,7 +133,13 @@ function defs(overrides: Partial<FullStatisticsPluginSettings> = {}): AnyDef[] {
 	return makeTab(overrides).tab.getSettingDefinitions();
 }
 
-/** The list that follows the labelled row carrying `name`. */
+type PageDef = Extract<AnyDef, { type: 'page' }>;
+
+/**
+ * The list that follows the row carrying `name`. `walk` yields a parent
+ * before its children, so this finds both a labelled row followed by its
+ * list and a standalone list that is the first item of its page.
+ */
 function listAfter(all: AnyDef[], name: string): ListDef {
 	const flat = [...walk(all)];
 	const idx = flat.findIndex(d => 'name' in d && d.name === name);
@@ -140,6 +147,14 @@ function listAfter(all: AnyDef[], name: string): ListDef {
 	const list = flat[idx + 1];
 	expect((list as ListDef).type).toBe('list');
 	return list as ListDef;
+}
+
+function page(all: AnyDef[], name: string): PageDef {
+	return [...walk(all)].find(d => 'type' in d && d.type === 'page' && d.name === name) as PageDef;
+}
+
+function pages(all: AnyDef[]): PageDef[] {
+	return [...walk(all)].filter(d => 'type' in d && d.type === 'page') as PageDef[];
 }
 
 /** Keys managed by a list editor rather than a bound control. */
@@ -187,14 +202,52 @@ describe("getSettingDefinitions", () => {
 	});
 });
 
-describe("visibility predicates", () => {
-	function group(all: AnyDef[], heading: string) {
-		return [...walk(all)].find(d => 'heading' in d && d.heading === heading)!;
-	}
+describe("tab layout", () => {
+	// The guard against sliding back into one long scroll: the first screen
+	// is an index, so nothing below the leading general row may render as a
+	// bare control or an editable list at the top level.
+	test("the top level is an index, not a wall of settings", () => {
+		const top = defs();
 
-	test("status bar item toggles follow displayIndividualItems", () => {
-		expect(resolve(group(defs({ displayIndividualItems: false }), "Status bar items").visible, true)).toBe(false);
-		expect(resolve(group(defs({ displayIndividualItems: true }), "Status bar items").visible, true)).toBe(true);
+		expect(top.filter(d => 'type' in d && d.type === 'list')).toEqual([]);
+
+		const [first, second, ...rest] = top;
+		expect(isControl(first) && first.control.key).toBe('displayIndividualItems');
+		expect((second as PageDef).type).toBe('page');
+		expect(rest.every(d => 'type' in d && d.type === 'group')).toBe(true);
+	});
+
+	test("the leading section carries no heading", () => {
+		const headings = defs()
+			.filter(d => 'heading' in d)
+			.map(d => (d as { heading?: string }).heading);
+		expect(headings).toEqual(["What gets counted", "Side view", "Tools"]);
+	});
+
+	test("every page summarises itself on the entry", () => {
+		const withoutSummary = pages(defs())
+			.filter(p => p.displayValue === undefined)
+			.map(p => p.name);
+		expect(withoutSummary).toEqual([]);
+	});
+
+	test("status bar items cover the statistics the status bar renders", () => {
+		const keys = STATUS_BAR_ITEMS.map(i => i.key);
+		expect(keys).toEqual([
+			'showNotes', 'showWords', 'showLinks', 'showTags', 'showQuality',
+			'showOwn', 'showSource', 'showOwnPct', 'showSourcePct',
+			'showConcepts', 'showOrphans', 'showTracePct',
+		]);
+		expect(page(defs(), "Status bar items").items).toHaveLength(keys.length);
+	});
+});
+
+describe("visibility predicates", () => {
+	// Cycling walks only the enabled statistics and skips the rest, so the
+	// per-item toggles matter in both modes and the page stays reachable.
+	test("status bar items stay reachable in cycling mode", () => {
+		expect(resolve(page(defs({ displayIndividualItems: false }), "Status bar items").visible, true)).toBe(true);
+		expect(resolve(page(defs({ displayIndividualItems: true }), "Status bar items").visible, true)).toBe(true);
 	});
 
 	test("tangles thresholds follow the selection mode", () => {
@@ -239,11 +292,6 @@ describe("control validation", () => {
 });
 
 describe("page summaries", () => {
-	function page(all: AnyDef[], name: string) {
-		return [...walk(all)].find(d => 'type' in d && d.type === 'page' && d.name === name) as
-			Extract<AnyDef, { type: 'page' }>;
-	}
-
 	test("a section that renders nothing is flagged", () => {
 		const enabledButEmpty = defs({ showFolderBreakdown: true, folderGroups: [] });
 		expect(resolve(page(enabledButEmpty, "Folder breakdown").status, null)).toBe('warning');
@@ -272,6 +320,43 @@ describe("page summaries", () => {
 		const all = defs({ showInbox: true, inboxFolders: ["00. Inbox", "Clippings"] });
 		expect(resolve(page(all, "Inbox health").displayValue, "")).toBe("2 folders");
 		expect(resolve(page(defs({ showInbox: false }), "Inbox health").displayValue, "")).toBe("Off");
+	});
+
+	test("toggle pages count what is enabled", () => {
+		// showConcepts is the one status bar item off by default.
+		expect(resolve(page(defs(), "Status bar items").displayValue, "")).toBe("11 of 12");
+		expect(resolve(page(defs({ showWords: false, showTags: false }), "Status bar items").displayValue, ""))
+			.toBe("9 of 12");
+		expect(resolve(page(defs(), "Metrics").displayValue, "")).toBe("5 of 5");
+		expect(resolve(page(defs({ metricsShowTags: false }), "Metrics").displayValue, "")).toBe("4 of 5");
+	});
+
+	test("an empty status bar is flagged", () => {
+		const allOff = Object.fromEntries(STATUS_BAR_ITEMS.map(i => [i.key, false]));
+		expect(resolve(page(defs(allOff), "Status bar items").status, null)).toBe('warning');
+		expect(resolve(page(defs({ showNotes: false }), "Status bar items").status, null)).toBeNull();
+	});
+
+	test("classification counts both sides and flags an empty one", () => {
+		expect(resolve(page(defs(), "Note classification").displayValue, "")).toBe("3 own / 6 source");
+		expect(resolve(page(defs(), "Note classification").status, null)).toBeNull();
+		expect(resolve(page(defs({ ownTags: [] }), "Note classification").status, null)).toBe('warning');
+		expect(resolve(page(defs({ sourceTags: [] }), "Note classification").status, null)).toBe('warning');
+	});
+
+	test("excluded folders and sections summarise their state", () => {
+		expect(resolve(page(defs(), "Excluded folders").displayValue, "")).toBe("No folders");
+		expect(resolve(page(defs({ excludedFolders: ["Templates"] }), "Excluded folders").displayValue, ""))
+			.toBe("1 folder");
+
+		expect(resolve(page(defs(), "Sources with trace").displayValue, "")).toBe("Off");
+		expect(resolve(page(defs({ showSourcesTrace: true }), "Sources with trace").displayValue, ""))
+			.toBe("On + top 5");
+		expect(resolve(page(defs({ showSourcesTrace: true, showDanglingList: false }), "Sources with trace").displayValue, ""))
+			.toBe("On");
+
+		expect(resolve(page(defs(), "History").displayValue, "")).toBe("Off");
+		expect(resolve(page(defs({ showHistory: true }), "History").displayValue, "")).toBe("On");
 	});
 
 	test("tangles summarises the active mode", () => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,6 +3,7 @@ import type {
 	ExtraButtonComponent,
 	Setting,
 	SettingDefinition,
+	SettingDefinitionGroup,
 	SettingDefinitionItem,
 	SettingDefinitionList,
 	SettingDefinitionPage,
@@ -130,6 +131,44 @@ const COLLECTOR_KEYS: ReadonlySet<string> = new Set<SettingsKey>([
 	"inboxReviewTags",
 ]);
 
+/** A togglable item: the row it renders and the settings key behind it. */
+interface ToggleItem {
+	key: SettingsKey;
+	name: string;
+	desc?: string;
+	aliases?: string[];
+}
+
+/**
+ * The status bar statistics, in the order the status bar renders them —
+ * `StatusBarView` builds its views and reads its enabled-flags in exactly
+ * this sequence. One source of truth for the toggle rows and the "N of 12"
+ * summary on the page entry.
+ */
+export const STATUS_BAR_ITEMS: readonly ToggleItem[] = [
+	{ key: 'showNotes', name: "Show notes" },
+	{ key: 'showWords', name: "Show words", desc: "Total word count across the vault." },
+	{ key: 'showLinks', name: "Show links" },
+	{ key: 'showTags', name: "Show tags" },
+	{ key: 'showQuality', name: "Show quality", aliases: ["QoV"] },
+	{ key: 'showOwn', name: "Show own notes", desc: "Notes tagged as your own thinking — see note classification." },
+	{ key: 'showSource', name: "Show source notes", desc: "Notes about external material — see note classification." },
+	{ key: 'showOwnPct', name: "Show own %", desc: "Share of own notes within own+source classified set." },
+	{ key: 'showSourcePct', name: "Show source %" },
+	{ key: 'showConcepts', name: "Show concept notes", desc: "Concepts are a grey zone — off by default." },
+	{ key: 'showOrphans', name: "Show orphans", desc: "Notes with no incoming links — disconnected knowledge.", aliases: ["disconnected"] },
+	{ key: 'showTracePct', name: "Show trace %", desc: "Share of source notes that at least one own note links to." },
+];
+
+/** Secondary metrics in the side view's grid, below the hero panel. */
+const METRICS_ITEMS: readonly ToggleItem[] = [
+	{ key: 'metricsShowLinks', name: "Links" },
+	{ key: 'metricsShowTags', name: "Tags" },
+	{ key: 'metricsShowConcepts', name: "Concepts" },
+	{ key: 'metricsShowOrphans', name: "Orphans" },
+	{ key: 'metricsShowAvgWords', name: "Avg words" },
+];
+
 export function parseFolderGroups(text: string): FolderGroup[] {
 	const groups: FolderGroup[] = [];
 	for (const rawLine of text.split("\n")) {
@@ -166,6 +205,14 @@ interface StringListOptions {
 	addLabel: string;
 	get: () => string[];
 	set: (items: string[]) => void;
+	/** Extra search terms for the labelled row. */
+	aliases?: string[];
+	/**
+	 * Drops the labelled row. Use on a page whose only content is this list —
+	 * the page title and description already say what the list is, and a row
+	 * repeating them reads as a duplicate.
+	 */
+	standalone?: boolean;
 	/** Whether the value feeds the collector and needs a rescan on change. */
 	affectsCollector?: boolean;
 	/** Opens a picker instead of appending a blank row. */
@@ -205,7 +252,27 @@ export class FullStatisticsPluginSettingTab extends PluginSettingTab {
 		this.refreshDomState();
 	}
 
+	/**
+	 * The tab is an index: the first screen carries only the one general
+	 * toggle and a list of navigable entries, each summarising its own state.
+	 * Everything else lives one level down.
+	 */
 	getSettingDefinitions(): SettingDefinitionItem<SettingsKey>[] {
+		return [
+			...this.general(),
+			this.counting(),
+			this.sideView(),
+			this.tools(),
+		];
+	}
+
+	/**
+	 * The leading section carries no heading: the tab title in the sidebar
+	 * already names the plugin, and headings only start to earn their keep
+	 * from the second section onwards.
+	 */
+	private general(): SettingDefinitionItem<SettingsKey>[] {
+		const enabled = () => STATUS_BAR_ITEMS.filter(i => this.plugin.settings[i.key]).length;
 		return [
 			{
 				name: "Show individual items",
@@ -213,226 +280,296 @@ export class FullStatisticsPluginSettingTab extends PluginSettingTab {
 				control: { type: 'toggle', key: 'displayIndividualItems', defaultValue: DEFAULT_SETTINGS.displayIndividualItems },
 			},
 			{
-				type: 'group',
-				heading: "Status bar items",
-				// Cycling mode shows one statistic at a time, so the
-				// per-item toggles only mean something when every item is
-				// rendered at once.
-				visible: () => this.plugin.settings.displayIndividualItems,
-				items: [
-					this.toggle("Show notes", 'showNotes'),
-					this.toggle("Show words", 'showWords', "Total word count across the vault."),
-					this.toggle("Show links", 'showLinks'),
-					this.toggle("Show tags", 'showTags'),
-					this.toggle("Show quality", 'showQuality'),
-					this.toggle("Show own notes", 'showOwn', "Notes tagged as your own thinking (own taxonomy below)."),
-					this.toggle("Show source notes", 'showSource', "Notes about external material (source taxonomy below)."),
-					this.toggle("Show own %", 'showOwnPct', "Share of own notes within own+source classified set."),
-					this.toggle("Show source %", 'showSourcePct'),
-					this.toggle("Show concept notes", 'showConcepts', "Concepts are a grey zone — off by default."),
-					this.toggle("Show orphans", 'showOrphans', "Notes with no incoming links — disconnected knowledge."),
-					this.toggle("Show trace %", 'showTracePct', "Share of source notes that at least one own note links to."),
-				],
-			},
-			{
-				type: 'group',
-				heading: "Metrics section",
-				items: [
-					this.toggle("Links", 'metricsShowLinks'),
-					this.toggle("Tags", 'metricsShowTags'),
-					this.toggle("Concepts", 'metricsShowConcepts'),
-					this.toggle("Orphans", 'metricsShowOrphans'),
-					this.toggle("Avg words", 'metricsShowAvgWords'),
-				],
-			},
-
-			...this.stringList({
-				name: "Excluded folders",
-				desc: "Folders to skip from statistics.",
-				placeholder: "e.g. Templates",
-				addLabel: "Add folder",
-				pick: 'folder',
-				get: () => this.plugin.settings.excludedFolders,
-				set: (items) => { this.plugin.settings.excludedFolders = items; },
-				affectsCollector: true,
-			}),
-			...this.stringList({
-				name: "Own tags",
-				desc: "Tags marking your own thinking. Leading # is optional.",
-				placeholder: "e.g. thought",
-				addLabel: "Add tag",
-				get: () => this.plugin.settings.ownTags,
-				set: (items) => { this.plugin.settings.ownTags = items; },
-				affectsCollector: true,
-			}),
-			...this.stringList({
-				name: "Source tags",
-				desc: "Tags marking notes about external material.",
-				placeholder: "e.g. book",
-				addLabel: "Add tag",
-				get: () => this.plugin.settings.sourceTags,
-				set: (items) => { this.plugin.settings.sourceTags = items; },
-				affectsCollector: true,
-			}),
-			...this.stringList({
-				name: "Concept tags",
-				desc: "Tags marking concept notes (the grey zone).",
-				placeholder: "e.g. concept",
-				addLabel: "Add tag",
-				get: () => this.plugin.settings.conceptTags,
-				set: (items) => { this.plugin.settings.conceptTags = items; },
-				affectsCollector: true,
-			}),
-
-			{
 				type: 'page',
-				name: "Folder breakdown",
-				desc: "Per-folder section in the statistics view (PARA-style).",
-				displayValue: () => this.plugin.settings.showFolderBreakdown
-					? count(this.plugin.settings.folderGroups.length, "group")
-					: "Off",
-				// The section renders nothing without groups, so an enabled
-				// toggle and an empty list is a silent no-op worth flagging.
-				status: () => this.plugin.settings.showFolderBreakdown
-					&& this.plugin.settings.folderGroups.length === 0 ? 'warning' : null,
-				items: [
-					this.toggle("Show folder breakdown", 'showFolderBreakdown', "Per-folder section in the statistics view (PARA-style)."),
-					...this.folderGroups(),
-				],
+				name: "Status bar items",
+				// These apply in both modes: cycling walks only the enabled
+				// items and skips over the rest.
+				desc: "Which statistics the status bar shows. Cycling mode skips the ones turned off here.",
+				displayValue: () => `${enabled()} of ${STATUS_BAR_ITEMS.length}`,
+				// Nothing enabled leaves the status bar blank in either mode.
+				status: () => enabled() === 0 ? 'warning' : null,
+				items: STATUS_BAR_ITEMS.map(i => this.toggle(i.name, i.key, i.desc, i.aliases)),
 			},
-
-			{
-				type: 'group',
-				heading: "Sources with trace",
-				items: [
-					this.toggle(
-						"Show sources-with-trace",
-						'showSourcesTrace',
-						"Section in the statistics view showing how many source notes are referenced by at least one own note (and which ones aren't).",
-					),
-					this.toggle(
-						"Show dangling notes list",
-						'showDanglingList',
-						"Inside Sources-with-trace: the top-5 list of source notes nothing links to. Off keeps just the bar and legend.",
-					),
-				],
-			},
-
-			{
-				type: 'page',
-				name: "Taxonomy drift",
-				desc: "Rare tags and tags outside your canonical set.",
-				displayValue: () => this.plugin.settings.showTaxonomyDrift
-					? count(this.plugin.settings.canonicalTags.length, "canonical tag")
-					: "Off",
-				// With no canonical set every tag reads as unknown, which
-				// makes the section noise rather than signal.
-				status: () => this.plugin.settings.showTaxonomyDrift
-					&& this.plugin.settings.canonicalTags.length === 0 ? 'warning' : null,
-				items: [
-					this.toggle(
-						"Show taxonomy drift",
-						'showTaxonomyDrift',
-						"Section in the statistics view that lists rare tags and tags outside your canonical set.",
-					),
-					{
-						name: "Rare tag threshold",
-						desc: "Tags used fewer than this many times are flagged as rare (likely typos or dead).",
-						control: {
-							type: 'number',
-							key: 'rareTagThreshold',
-							defaultValue: DEFAULT_SETTINGS.rareTagThreshold,
-							placeholder: String(DEFAULT_SETTINGS.rareTagThreshold),
-							min: 1,
-							step: 1,
-							validate: (value) => Number.isInteger(value) && value >= 1
-								? undefined
-								: "Must be a whole number of 1 or more.",
-						},
-					},
-					...this.stringList({
-						name: "Canonical tags",
-						desc: "Your accepted tag set. Anything else is flagged as unknown. A canonical parent (e.g. 'journal') covers descendants ('journal/daily').",
-						placeholder: "e.g. thought",
-						addLabel: "Add tag",
-						get: () => this.plugin.settings.canonicalTags,
-						set: (items) => { this.plugin.settings.canonicalTags = items; },
-					}),
-				],
-			},
-
-			{
-				type: 'page',
-				name: "Inbox health",
-				desc: "Notes in inbox folders and notes tagged for review, bucketed by age (<1d / 1–7d / 7–30d / 30+d).",
-				displayValue: () => this.plugin.settings.showInbox
-					? count(this.plugin.settings.inboxFolders.length, "folder")
-					: "Off",
-				// Neither folders nor review tags means nothing is ever
-				// collected — the section stays empty and copy refuses.
-				status: () => this.plugin.settings.showInbox
-					&& this.plugin.settings.inboxFolders.length === 0
-					&& this.plugin.settings.inboxReviewTags.length === 0 ? 'warning' : null,
-				items: [
-					this.toggle(
-						"Show inbox health",
-						'showInbox',
-						"Section showing notes in inbox folders and notes outside them tagged with a review tag, bucketed by age (<1d / 1–7d / 7–30d / 30+d).",
-					),
-					...this.stringList({
-						name: "Inbox folders",
-						desc: "Folders treated as inbox (techdebt of unprocessed input).",
-						placeholder: "e.g. 00. Входящие",
-						addLabel: "Add folder",
-						pick: 'folder',
-						get: () => this.plugin.settings.inboxFolders,
-						set: (items) => { this.plugin.settings.inboxFolders = items; },
-						affectsCollector: true,
-					}),
-					...this.stringList({
-						name: "Inbox review tags",
-						desc: "Tags marking notes that need processing even when outside inbox folders. Leading # is optional.",
-						placeholder: "e.g. inbox/review",
-						addLabel: "Add tag",
-						get: () => this.plugin.settings.inboxReviewTags,
-						set: (items) => { this.plugin.settings.inboxReviewTags = items; },
-						affectsCollector: true,
-					}),
-				],
-			},
-
-			{
-				type: 'group',
-				heading: "History",
-				items: [
-					this.toggle(
-						"Show history",
-						'showHistory',
-						"30-day sparkline section in the statistics view. Snapshots are recorded daily regardless of this toggle.",
-					),
-					{
-						name: "History export folder",
-						desc: "Last folder used for CSV export. The export command opens a folder picker each time and updates this value.",
-						control: {
-							type: 'folder',
-							key: 'historyExportFolder',
-							defaultValue: DEFAULT_SETTINGS.historyExportFolder,
-							placeholder: "(vault root)",
-							includeRoot: true,
-						},
-					},
-				],
-			},
-
-			this.tangles(),
 		];
 	}
 
+	/** What the collector sees: the folders it skips and the tags it sorts by. */
+	private counting(): SettingDefinitionGroup<SettingsKey> {
+		const s = () => this.plugin.settings;
+		return {
+			type: 'group',
+			heading: "What gets counted",
+			items: [
+				{
+					type: 'page',
+					name: "Excluded folders",
+					desc: "Folders to skip from statistics. Matched as a path prefix, so a folder covers everything under it.",
+					displayValue: () => count(s().excludedFolders.length, "folder"),
+					items: this.stringList({
+						name: "Excluded folders",
+						desc: "Folders to skip from statistics.",
+						aliases: ["ignore", "skip"],
+						standalone: true,
+						placeholder: "e.g. Templates",
+						addLabel: "Add folder",
+						pick: 'folder',
+						get: () => s().excludedFolders,
+						set: (items) => { s().excludedFolders = items; },
+						affectsCollector: true,
+					}),
+				},
+				{
+					type: 'page',
+					name: "Note classification",
+					desc: "Tags that sort notes into your own thinking, external material, and concepts.",
+					displayValue: () => `${s().ownTags.length} own / ${s().sourceTags.length} source`,
+					// Own/source is the headline metric of the whole plugin;
+					// an empty side leaves the hero panel meaningless.
+					status: () => s().ownTags.length === 0 || s().sourceTags.length === 0 ? 'warning' : null,
+					items: [
+						...this.stringList({
+							name: "Own tags",
+							desc: "Tags marking your own thinking. Leading # is optional.",
+							aliases: ["classification", "zettelkasten"],
+							placeholder: "e.g. thought",
+							addLabel: "Add tag",
+							get: () => s().ownTags,
+							set: (items) => { s().ownTags = items; },
+							affectsCollector: true,
+						}),
+						...this.stringList({
+							name: "Source tags",
+							desc: "Tags marking notes about external material.",
+							aliases: ["classification", "literature"],
+							placeholder: "e.g. book",
+							addLabel: "Add tag",
+							get: () => s().sourceTags,
+							set: (items) => { s().sourceTags = items; },
+							affectsCollector: true,
+						}),
+						...this.stringList({
+							name: "Concept tags",
+							desc: "Tags marking concept notes (the grey zone).",
+							aliases: ["classification"],
+							placeholder: "e.g. concept",
+							addLabel: "Add tag",
+							get: () => s().conceptTags,
+							set: (items) => { s().conceptTags = items; },
+							affectsCollector: true,
+						}),
+					],
+				},
+			],
+		};
+	}
+
+	/**
+	 * Every optional section of the statistics view, one entry each. Two of
+	 * them hold only a pair of toggles, but a section that looks like its
+	 * neighbours is worth more here than a row saved: the alternative is an
+	 * index with loose toggles wedged between navigable entries, and the API
+	 * does not let a group nest inside another group.
+	 */
+	private sideView(): SettingDefinitionGroup<SettingsKey> {
+		return {
+			type: 'group',
+			heading: "Side view",
+			items: [
+				this.metrics(),
+				this.folderBreakdown(),
+				this.sourcesTrace(),
+				this.taxonomyDrift(),
+				this.inboxHealth(),
+				this.history(),
+			],
+		};
+	}
+
+	private tools(): SettingDefinitionGroup<SettingsKey> {
+		return {
+			type: 'group',
+			heading: "Tools",
+			items: [this.tangles()],
+		};
+	}
+
+	private metrics(): SettingDefinitionPage<SettingsKey> {
+		const enabled = () => METRICS_ITEMS.filter(i => this.plugin.settings[i.key]).length;
+		return {
+			type: 'page',
+			name: "Metrics",
+			desc: "Secondary metrics in the grid below the hero panel.",
+			displayValue: () => `${enabled()} of ${METRICS_ITEMS.length}`,
+			items: METRICS_ITEMS.map(i => this.toggle(i.name, i.key, i.desc, i.aliases)),
+		};
+	}
+
+	private folderBreakdown(): SettingDefinitionPage<SettingsKey> {
+		return {
+			type: 'page',
+			name: "Folder breakdown",
+			desc: "Per-folder section in the statistics view (PARA-style).",
+			displayValue: () => this.plugin.settings.showFolderBreakdown
+				? count(this.plugin.settings.folderGroups.length, "group")
+				: "Off",
+			// The section renders nothing without groups, so an enabled
+			// toggle and an empty list is a silent no-op worth flagging.
+			status: () => this.plugin.settings.showFolderBreakdown
+				&& this.plugin.settings.folderGroups.length === 0 ? 'warning' : null,
+			items: [
+				this.toggle("Show folder breakdown", 'showFolderBreakdown', "Per-folder section in the statistics view (PARA-style).", ["PARA"]),
+				...this.folderGroups(),
+			],
+		};
+	}
+
+	private sourcesTrace(): SettingDefinitionPage<SettingsKey> {
+		const s = () => this.plugin.settings;
+		return {
+			type: 'page',
+			name: "Sources with trace",
+			desc: "How many source notes are referenced by at least one own note.",
+			displayValue: () => !s().showSourcesTrace
+				? "Off"
+				: s().showDanglingList ? "On + top 5" : "On",
+			items: [
+				this.toggle(
+					"Show sources-with-trace",
+					'showSourcesTrace',
+					"Section in the statistics view showing how many source notes are referenced by at least one own note (and which ones aren't).",
+				),
+				this.toggle(
+					"Show dangling notes list",
+					'showDanglingList',
+					"Inside Sources-with-trace: the top-5 list of source notes nothing links to. Off keeps just the bar and legend.",
+					["dangling", "untraced"],
+				),
+			],
+		};
+	}
+
+	private taxonomyDrift(): SettingDefinitionPage<SettingsKey> {
+		return {
+			type: 'page',
+			name: "Taxonomy drift",
+			desc: "Rare tags and tags outside your canonical set.",
+			displayValue: () => this.plugin.settings.showTaxonomyDrift
+				? count(this.plugin.settings.canonicalTags.length, "canonical tag")
+				: "Off",
+			// With no canonical set every tag reads as unknown, which
+			// makes the section noise rather than signal.
+			status: () => this.plugin.settings.showTaxonomyDrift
+				&& this.plugin.settings.canonicalTags.length === 0 ? 'warning' : null,
+			items: [
+				this.toggle(
+					"Show taxonomy drift",
+					'showTaxonomyDrift',
+					"Section in the statistics view that lists rare tags and tags outside your canonical set.",
+				),
+				{
+					name: "Rare tag threshold",
+					desc: "Tags used fewer than this many times are flagged as rare (likely typos or dead).",
+					control: {
+						type: 'number',
+						key: 'rareTagThreshold',
+						defaultValue: DEFAULT_SETTINGS.rareTagThreshold,
+						placeholder: String(DEFAULT_SETTINGS.rareTagThreshold),
+						min: 1,
+						step: 1,
+						validate: (value) => Number.isInteger(value) && value >= 1
+							? undefined
+							: "Must be a whole number of 1 or more.",
+					},
+				},
+				...this.stringList({
+					name: "Canonical tags",
+					desc: "Your accepted tag set. Anything else is flagged as unknown. A canonical parent (e.g. 'journal') covers descendants ('journal/daily').",
+					placeholder: "e.g. thought",
+					addLabel: "Add tag",
+					get: () => this.plugin.settings.canonicalTags,
+					set: (items) => { this.plugin.settings.canonicalTags = items; },
+				}),
+			],
+		};
+	}
+
+	private inboxHealth(): SettingDefinitionPage<SettingsKey> {
+		return {
+			type: 'page',
+			name: "Inbox health",
+			desc: "Notes in inbox folders and notes tagged for review, bucketed by age (<1d / 1–7d / 7–30d / 30+d).",
+			displayValue: () => this.plugin.settings.showInbox
+				? count(this.plugin.settings.inboxFolders.length, "folder")
+				: "Off",
+			// Neither folders nor review tags means nothing is ever
+			// collected — the section stays empty and copy refuses.
+			status: () => this.plugin.settings.showInbox
+				&& this.plugin.settings.inboxFolders.length === 0
+				&& this.plugin.settings.inboxReviewTags.length === 0 ? 'warning' : null,
+			items: [
+				this.toggle(
+					"Show inbox health",
+					'showInbox',
+					"Section showing notes in inbox folders and notes outside them tagged with a review tag, bucketed by age (<1d / 1–7d / 7–30d / 30+d).",
+				),
+				...this.stringList({
+					name: "Inbox folders",
+					desc: "Folders treated as inbox (techdebt of unprocessed input).",
+					placeholder: "e.g. 00. Входящие",
+					addLabel: "Add folder",
+					pick: 'folder',
+					get: () => this.plugin.settings.inboxFolders,
+					set: (items) => { this.plugin.settings.inboxFolders = items; },
+					affectsCollector: true,
+				}),
+				...this.stringList({
+					name: "Inbox review tags",
+					desc: "Tags marking notes that need processing even when outside inbox folders. Leading # is optional.",
+					placeholder: "e.g. inbox/review",
+					addLabel: "Add tag",
+					get: () => this.plugin.settings.inboxReviewTags,
+					set: (items) => { this.plugin.settings.inboxReviewTags = items; },
+					affectsCollector: true,
+				}),
+			],
+		};
+	}
+
+	private history(): SettingDefinitionPage<SettingsKey> {
+		return {
+			type: 'page',
+			name: "History",
+			desc: "30-day sparkline of how the vault evolves.",
+			displayValue: () => this.plugin.settings.showHistory ? "On" : "Off",
+			items: [
+				this.toggle(
+					"Show history",
+					'showHistory',
+					"30-day sparkline section in the statistics view. Snapshots are recorded daily regardless of this toggle.",
+					["sparkline"],
+				),
+				{
+					name: "History export folder",
+					desc: "Last folder used for CSV export. The export command opens a folder picker each time and updates this value.",
+					aliases: ["CSV"],
+					control: {
+						type: 'folder',
+						key: 'historyExportFolder',
+						defaultValue: DEFAULT_SETTINGS.historyExportFolder,
+						placeholder: "(vault root)",
+						includeRoot: true,
+					},
+				},
+			],
+		};
+	}
+
 	/** Boolean row bound straight to a settings key. */
-	private toggle(name: string, key: SettingsKey, desc?: string): SettingDefinition<SettingsKey> {
+	private toggle(name: string, key: SettingsKey, desc?: string, aliases?: string[]): SettingDefinition<SettingsKey> {
 		return {
 			name,
 			desc,
+			aliases,
 			control: { type: 'toggle', key, defaultValue: DEFAULT_SETTINGS[key] as boolean },
 		};
 	}
@@ -633,7 +770,8 @@ export class FullStatisticsPluginSettingTab extends PluginSettingTab {
 			}];
 		}
 
-		return [{ name: opts.name, desc: opts.desc }, list];
+		if (opts.standalone) return [list];
+		return [{ name: opts.name, desc: opts.desc, aliases: opts.aliases }, list];
 	}
 
 	/**


### PR DESCRIPTION
## Зачем

Экран настроек рендерился одной портянкой: 28 строк при дефолтах и ~40, если включить `Show individual items`. На одном уровне лежали сущности разного веса — одиночный тумблер, блок из 12 чекбоксов статус-бара, блок из 5 чекбоксов метрик, четыре редактируемых списка и четыре навигационные страницы, добавленные в 1.21.0. Списки — худший случай: `sourceTags` с шестью дефолтными значениями съедал семь строк, хотя после первичной настройки к нему не возвращаются.

## Что стало

```
Show individual items
Status bar items ›            11 of 12
[What gets counted]
  Excluded folders ›          1 folder
  Note classification ›       3 own / 6 source
[Side view]
  Metrics ›                   5 of 5
  Folder breakdown ›          1 group
  Sources with trace ›        Off
  Taxonomy drift ›            No canonical tags ⚠
  Inbox health ›              2 folders
  History ›                   Off
[Tools]
  Tangles ›                   AND ≥ 5/5
```

15 строк вместо 28–40. Ни одна настройка не удалена, не переименована и не получила новый дефолт — всё уехало уровнем ниже и по-прежнему находится через `Settings → Search`.

Раскладка следует официальному гайду Obsidian: общая секция идёт первой и без заголовка (вкладка в сайдбаре уже названа именем плагина), sentence case, подстраницы там, где вкладка не сканируется за экран. Всё на нативном `SettingDefinitionPage` — никаких самодельных аккордеонов и табов, которые выпадают из индекса поиска настроек.

## Изменения

- `getSettingDefinitions()` собирается из методов-секций: `general`, `counting`, `sideView`, `tools`.
- Каждая секция бокового вида — `type: 'page'`, включая две, где всего по паре тумблеров: индекс читается лучше, когда записи однородны, а вложить группу в группу API не даёт.
- 12 тумблеров статус-бара и 5 тумблеров метрик генерируются из `STATUS_BAR_ITEMS` / `METRICS_ITEMS`. `StatusBarView.viewEnabledFlags()` читает тот же список вместо своей копии двенадцати ключей, так что вкладка и статус-бар больше не разъедутся.
- У каждой записи появилась сводка состояния: `11 of 12`, `3 own / 6 source`, `No folders`, `On + top 5`. Раньше сводка была у четырёх из десяти.
- Два новых warning-маркера на конфигурации, которые молча ничего не рендерят: все 12 статистик выключены (пустой статус-бар) и пустой `ownTags` либо `sourceTags`.
- `stringList()` получил `standalone` (страница с единственным списком не дублирует свой заголовок строкой-подписью) и `aliases` для поиска.
- `minAppVersion` 1.13.0 → 1.13.1: `displayValue` и `status` помечены `@since 1.13.1` и приехали ещё в 1.21.0, манифест занижал требование с прошлого релиза.

## Fixed

Тумблеры отдельных статистик больше не прячутся при выключенном `Show individual items`. Комментарий утверждал, что в режиме циклирования они ничего не значат, но `advanceToEnabled()` всегда пропускал выключенные элементы, а `refresh()` перематывал на следующий включённый. Настройки работали, а UI их скрывал.

## Проверено

- `npm test` — 204 теста зелёные (было 196). Новые: форма верхнего уровня (никаких списков и голых контролов в корне, заголовки только со второй секции), наличие `displayValue` у каждой страницы, порядок `STATUS_BAR_ITEMS`, новые сводки и warning'и.
- `npm run build` (`tsc -noEmit` + esbuild) и `npm run lint` — чисто.
- Структура проверена дампом дерева определений (см. блок выше).
- **Не проверено руками в Obsidian.** Стоит пройтись по десяти страницам, проверить возврат по «назад» и что глобальный поиск настроек открывает нужную страницу.
