### PR TITLE
fix(settings): count classification folders in the summary and warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this plugin are recorded here. Format follows [Keep a Cha
 ### Added
 - **Concept folders**, **Own folders** and **Source folders** settings (`Settings → What gets counted → Note classification`). Notes under a configured folder now count toward that classification even without the matching tag, for vaults that sort own/source/concept notes by location instead of tagging each one individually. Closes [#55](https://github.com/jtprogru/obsidian-vault-full-statistics-plugin/issues/55).
 
+### Fixed
+- The **Note classification** settings entry now counts folders alongside tags in its summary and only warns when own or source has neither a tag nor a folder. A vault classified purely by folder no longer reads `0 own / 0 source` under a warning. Closes [#57](https://github.com/jtprogru/obsidian-vault-full-statistics-plugin/issues/57).
+
 ## [1.24.2] - 2026-08-11
 
 A maintenance release. The build toolchain moved to TypeScript 7 and the rest of the dev dependencies were refreshed. Nothing the plugin ships or does changed — no source file was touched, and the linter rule set is identical to the previous one.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Editable lists — excluded folders, the tag sets, folder groups, inbox folders 
 
 ### What gets counted
 - **Excluded folders** — folders to skip entirely (templates, archives, plugin data). Added through the vault folder picker; matched as path prefix with a `/` boundary.
-- **Note classification** — the three tag sets behind own/source and the hero panel. The entry warns when either own or source is empty, because the ratio is meaningless then.
+- **Note classification** — the three tag sets and their matching folder lists behind own/source and the hero panel. A side counts as configured when it has a tag or a folder; the entry warns only when own or source has neither, because the ratio is meaningless then.
   - **Own tags** (default: `thought`, `synthesis`, `fleeting`) — mark notes as your own thinking.
   - **Own folders** (default: none) — folders whose notes count as your own thinking whether or not they carry an own tag.
   - **Source tags** (default: `book`, `article`, `video`, `lecture`, `literature`, `literature-note`) — mark notes about external material.

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -125,7 +125,7 @@ export const en = {
 			excludedPlaceholder: "e.g. Templates",
 
 			classificationName: "Note classification",
-			classificationDesc: "Tags that sort notes into your own thinking, external material, and concepts.",
+			classificationDesc: "Tags and folders that sort notes into your own thinking, external material, and concepts.",
 			classificationValue: (own: number, source: number) => `${own} own / ${source} source`,
 			ownTags: "Own tags",
 			ownTagsDesc: "Tags marking your own thinking. Leading # is optional.",

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -122,7 +122,7 @@ export const ru: Translations = {
 			excludedPlaceholder: "например, Templates",
 
 			classificationName: "Классификация заметок",
-			classificationDesc: "Теги, по которым заметки делятся на своё мышление, внешний материал и концепты.",
+			classificationDesc: "Теги и папки, по которым заметки делятся на своё мышление, внешний материал и концепты.",
 			classificationValue: (own, source) => `${own} своих / ${source} источников`,
 			ownTags: "Теги своих заметок",
 			ownTagsDesc: "Теги, помечающие ваше собственное мышление. Ведущий # необязателен.",

--- a/src/settings.spec.ts
+++ b/src/settings.spec.ts
@@ -394,6 +394,25 @@ describe("page summaries", () => {
 		expect(resolve(page(defs({ sourceTags: [] }), "Note classification").status, null)).toBe('warning');
 	});
 
+	test("classification counts folders alongside tags", () => {
+		const withFolders = defs({ ownFolders: ["01. Journal"], sourceFolders: ["02. Reading", "03. Clippings"] });
+		expect(resolve(page(withFolders, "Note classification").displayValue, "")).toBe("4 own / 8 source");
+	});
+
+	test("a side classified only by folder is not flagged", () => {
+		const foldersOnly = defs({
+			ownTags: [], ownFolders: ["01. Journal"],
+			sourceTags: [], sourceFolders: ["02. Reading"],
+		});
+		expect(resolve(page(foldersOnly, "Note classification").status, null)).toBeNull();
+		expect(resolve(page(foldersOnly, "Note classification").displayValue, "")).toBe("1 own / 1 source");
+	});
+
+	test("a side with neither a tag nor a folder is still flagged", () => {
+		const noOwn = defs({ ownTags: [], ownFolders: [], sourceFolders: ["02. Reading"] });
+		expect(resolve(page(noOwn, "Note classification").status, null)).toBe('warning');
+	});
+
 	test("excluded folders and sections summarise their state", () => {
 		expect(resolve(page(defs(), "Excluded folders").displayValue, "")).toBe("No folders");
 		expect(resolve(page(defs({ excludedFolders: ["Templates"] }), "Excluded folders").displayValue, ""))

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -392,10 +392,16 @@ export class FullStatisticsPluginSettingTab extends PluginSettingTab {
 					type: 'page',
 					name: t().settings.counting.classificationName,
 					desc: t().settings.counting.classificationDesc,
-					displayValue: () => t().settings.counting.classificationValue(s().ownTags.length, s().sourceTags.length),
+					displayValue: () => t().settings.counting.classificationValue(
+						s().ownTags.length + s().ownFolders.length,
+						s().sourceTags.length + s().sourceFolders.length,
+					),
 					// Own/source is the headline metric of the whole plugin;
-					// an empty side leaves the hero panel meaningless.
-					status: () => s().ownTags.length === 0 || s().sourceTags.length === 0 ? 'warning' : null,
+					// an empty side leaves the hero panel meaningless. A folder
+					// classifies just as well as a tag, so a side counts as
+					// configured when either list has something in it.
+					status: () => s().ownTags.length + s().ownFolders.length === 0
+						|| s().sourceTags.length + s().sourceFolders.length === 0 ? 'warning' : null,
 					items: [
 						this.stringList({
 							name: t().settings.counting.ownTags,


### PR DESCRIPTION
## Зачем

После #56 заметку можно классифицировать по папке, но карточка `Note classification` осталась тег-ориентированной: она читала только длины тег-листов. Vault, размеченный исключительно папками — ровно то, о чём просили в #55 — видел `0 own / 0 source` и ворнинг, хотя hero-панель при этом считала соотношение корректно.

## Что изменилось

- `src/settings.ts` — сводка карточки складывает теги и папки на каждой стороне, ворнинг срабатывает только когда у стороны нет ни тега, ни папки.
- `src/i18n/locales/{en,ru}.ts` — `classificationDesc` теперь говорит про теги **и** папки.
- `README.md` — раздел Settings reference описывает новое условие ворнинга.
- `CHANGELOG.md` — запись под `Unreleased → Fixed`.
- `src/settings.spec.ts` — три теста: папки складываются с тегами в сводке, папочная сторона не флагается, сторона без тега и без папки флагается по-прежнему.

## Как проверить

`npm run lint` чистый, `npm test` — 233 теста (было 230), `npm run build` собирается. Руками: очистить Own tags и Source tags, добавить по одной папке в Own folders и Source folders — карточка должна показать `1 own / 1 source` без ворнинга.

Closes #57
