### PR TITLE
fix(history): never record an empty vault reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this plugin are recorded here. Format follows [Keep a Cha
 - **Concept folders**, **Own folders** and **Source folders** settings (`Settings → What gets counted → Note classification`). Notes under a configured folder now count toward that classification even without the matching tag, for vaults that sort own/source/concept notes by location instead of tagging each one individually. Closes [#55](https://github.com/jtprogru/obsidian-vault-full-statistics-plugin/issues/55).
 
 ### Fixed
+- Reloading the plugin no longer stamps a zeros row into today's history. A rescan zeroes the collector's metrics before the backlog drains, and the snapshot taken in that window used to overwrite the day's real reading; an empty reading is now never recorded, and the snapshot debounce waits for the vault to go quiet instead of firing ten seconds after the rescan started. Closes [#54](https://github.com/jtprogru/obsidian-vault-full-statistics-plugin/issues/54).
 - The **Note classification** settings entry now counts folders alongside tags in its summary and only warns when own or source has neither a tag nor a folder. A vault classified purely by folder no longer reads `0 own / 0 source` under a warning. Closes [#57](https://github.com/jtprogru/obsidian-vault-full-statistics-plugin/issues/57).
 
 ## [1.24.2] - 2026-08-11

--- a/src/historyStore.spec.ts
+++ b/src/historyStore.spec.ts
@@ -37,6 +37,32 @@ describe("HistoryStore.recordIfNeeded", () => {
 		expect(h.all()[0].notes).toBe(105);
 	});
 
+	test("an empty reading never replaces today's row", () => {
+		const h = new HistoryStore();
+		h.recordIfNeeded(new Date("2026-05-08T10:00:00"), makeMetrics({ notes: 6179, links: 46996, ownNotes: 2149 }));
+		// What a plugin reload produces: metrics zeroed by the rescan, with
+		// the tag count already refreshed.
+		const changed = h.recordIfNeeded(new Date("2026-05-08T18:00:00"), makeMetrics({ notes: 0, tags: 123 }));
+		expect(changed).toBe(false);
+		expect(h.size()).toBe(1);
+		expect(h.all()[0]).toMatchObject({ notes: 6179, links: 46996, ownNotes: 2149 });
+	});
+
+	test("an empty reading does not open a row for a fresh day", () => {
+		const h = new HistoryStore();
+		const changed = h.recordIfNeeded(new Date("2026-05-08T10:00:00"), makeMetrics({ notes: 0, tags: 123 }));
+		expect(changed).toBe(false);
+		expect(h.size()).toBe(0);
+	});
+
+	test("a real reading after an empty one is recorded normally", () => {
+		const h = new HistoryStore();
+		h.recordIfNeeded(new Date("2026-05-08T10:00:00"), makeMetrics({ notes: 0 }));
+		const changed = h.recordIfNeeded(new Date("2026-05-08T10:00:10"), makeMetrics({ notes: 6179 }));
+		expect(changed).toBe(true);
+		expect(h.all()[0].notes).toBe(6179);
+	});
+
 	test("appends a new snapshot on a new day", () => {
 		const h = new HistoryStore();
 		h.recordIfNeeded(new Date("2026-05-08T10:00:00"), makeMetrics({ notes: 100 }));

--- a/src/historyStore.ts
+++ b/src/historyStore.ts
@@ -33,9 +33,18 @@ export class HistoryStore {
 	 * the *latest known* state of the vault rather than the first reading
 	 * of the morning.
 	 *
+	 * A reading of zero notes is never recorded. The collector resets its
+	 * metrics to zero at the start of every rescan and only fills them in as
+	 * the backlog drains, so a snapshot taken in that window describes the
+	 * scan, not the vault — and since a same-date row is overwritten rather
+	 * than appended, it would replace a real reading with a crater. An empty
+	 * vault has nothing worth charting, so the guard costs no real data.
+	 *
 	 * Returns true if the snapshots array was mutated.
 	 */
 	public recordIfNeeded(now: Date, metrics: FullVaultMetrics): boolean {
+		if (metrics.notes === 0) return false;
+
 		const date = formatDate(now);
 		const snapshot: Snapshot = {
 			date,

--- a/src/main.ts
+++ b/src/main.ts
@@ -159,12 +159,17 @@ export default class FullStatisticsPlugin extends Plugin {
 		await this.saveData(payload);
 	}
 
+	// resetTimer is on so the window measures quiet, not elapsed time since
+	// the first event. A rescan fires 'updated' the moment it zeroes the
+	// metrics, and on a large vault the backlog drains through idle
+	// callbacks well past the ten-second mark — without the reset we would
+	// sample in the middle of it and record a vault that looks empty.
 	private maybeSnapshot = debounce(() => {
 		const changed = this.historyStore.recordIfNeeded(new Date(), this.vaultMetrics);
 		if (changed) {
 			void this.persist();
 		}
-	}, 10000, false);
+	}, 10000, true);
 
 	private async exportHistoryCsv() {
 		const snapshots = this.historyStore.all();


### PR DESCRIPTION
## Зачем

Перезагрузка плагина затирала сегодняшнюю строку истории нулями (#54). `rescan()` обнуляет метрики и тут же дёргает `refreshTagCount()`, который шлёт `updated` — отсюда и характерная строка `notes: 0, tags: 123`: теги успели посчитаться синхронно, заметки ещё нет. Дебаунс срабатывал через 10 секунд, бэклог на большом vault к этому моменту не разобран, а `recordIfNeeded` перезаписывает строку за ту же дату, а не добавляет новую. Если Obsidian закрыть сразу после reload, нули оставались в `data.json` навсегда.

## Что изменилось

- `src/historyStore.ts` — `recordIfNeeded` отказывается писать чтение с `notes === 0`. Существующая строка остаётся нетронутой; пустой vault нечего рисовать в спарклайне, так что реальных данных guard не стоит.
- `src/main.ts` — у дебаунса снапшота включён `resetTimer`. Комментарий над ним всегда обещал «sample after the vault has settled rather than mid-backlog», но с `resetTimer=false` окно отсчитывалось от первого события, то есть от начала пересканирования. Теперь окно измеряет тишину, и на большом vault, который разбирает бэклог через `requestIdleCallback`, снапшот снимается с осевшего состояния.
- `src/historyStore.spec.ts` — три теста: нулевое чтение не трогает существующую строку, не заводит новую строку на пустой день, и следом за ним обычное чтение записывается штатно.

Вторая половина issue — «почему нули не заживают сами» — закрывается тем же: строка теперь просто не появляется, а следующее реальное чтение перезаписывает день как обычно.

## Как проверить

`npm run lint` чистый, `npm test` — 236 тестов (было 233), `npm run build` собирается. Если убрать guard из `recordIfNeeded`, два новых теста падают — проверено.

Руками: открыть vault с непустой историей, сделать `obsidian plugin:reload id=vault-full-statistics`, посмотреть `.obsidian/plugins/vault-full-statistics/data.json` — строка за сегодня должна сохранить реальные числа.

Closes #54
