### PR TITLE
docs(changelog): note the Makefile replacing Taskfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this plugin are recorded here. Format follows [Keep a Cha
 
 ## [Unreleased]
 
+### Changed
+- Development commands moved from `Taskfile.yml` to a `Makefile`, dropping [Task](https://taskfile.dev) as a prerequisite for what `make` does out of the box. The previous targets are unchanged — `install`, `build`, `test`, `lint`, `dev`, `version` — and `make` on its own lists everything. New: `check` runs the pipeline CI runs (lockfile install, lint, test, build), `deploy VAULT=/path/to/vault` builds and copies `main.js`, `styles.css` and `manifest.json` into a vault, `tag` creates the release tag from `package.json` and refuses when the tag exists or `manifest.json` disagrees on the version, plus `ci-install`, `typecheck`, `test-watch`, `coverage`, `lint-fix` and `clean`. Nothing the plugin ships changed, and the workflows still call `npm` directly, so `make` is not needed on the runners ([#61](https://github.com/jtprogru/obsidian-vault-full-statistics-plugin/pull/61)).
+
 ## [1.25.0] - 2026-08-29
 
 Note classification stops being tag-only. Own, source and concept notes can now be recognised by the folder they live in, which is how many vaults are actually organised — a folder of concepts does not need every note in it tagged `#concept` to be counted. Alongside that, a plugin reload no longer damages the day's history row.


### PR DESCRIPTION
## Зачем

#61 сменил обвязку для разработки, но в `CHANGELOG.md` это не попало. Секция `Unreleased` пустовала с момента релиза 1.25.0, а следующий релизный PR собирает release notes именно из неё — без записи изменение просто выпало бы из истории.

## Что изменилось

Один пункт в `## [Unreleased] → ### Changed`: переход с `Taskfile.yml` на `Makefile`, сохранённые прежние цели, новые (`check`, `deploy`, `tag`, `ci-install`, `typecheck`, `test-watch`, `coverage`, `lint-fix`, `clean`) и оговорка, что на плагин и на CI это не влияет — workflow'ы по-прежнему зовут `npm` напрямую.

Формат как у записи 1.24.2 про смену тулинга: прозой, со ссылкой на PR в конце.

## Как проверить

Изменение только в `CHANGELOG.md`, кода не касается. `awk` из `release.yaml` секцию `Unreleased` не трогает — он ищет `## [<version>]`, так что на извлечение release notes это не влияет до тех пор, пока секция не будет закрыта номером версии.

## Риски

Нет. Bump версии этот PR не делает.